### PR TITLE
License folder convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-﻿# may contain OAuth secrets, do not commit
+﻿# ignore the license file
+license.xml
+
+# may contain OAuth secrets, do not commit
 .sitecore/user.json
 
 # NuGet cache for Sitecore CLI

--- a/README.md
+++ b/README.md
@@ -2,21 +2,23 @@
 
 ## QUICK START
 
-1. In an ADMIN terminal:
+1. Copy your license file to the license folde:
+
+2. In an ADMIN terminal:
 
     ```ps1
-    .\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
+    .\init.ps1 -InitEnv -AdminPassword "DesiredAdminPassword"
     ```
 
-2. Restart your terminal and run:
+3. Restart your terminal and run:
 
     ```ps1
     .\up.ps1
     ```
 
-3. Follow the instructions to [deploy to XM Cloud](#deploy-to-xmcloud)
+4. Follow the instructions to [deploy to XM Cloud](#deploy-to-xmcloud)
 
-4. Create Edge token and [query from edge](#query-edge)
+5. Create Edge token and [query from edge](#query-edge)
 
 *** 
 
@@ -24,4 +26,10 @@
 This solution is designed to help developers learn and get started quickly
 with XMCLoud + SXA.
 
+## License File
 
+If you store your license file in a central location, you can pass a LicenseXmlPath paramter to the init command to use that location. 
+
+    ```ps1
+    .\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
+    ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## QUICK START
 
-1. Copy your license file to the license folde:
+1. Copy your license file to the license folder
 
 2. In an ADMIN terminal:
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 
 If you store your license file in a central location, you can pass a LicenseXmlPath paramter to the init command to use that location. 
 
-    ```ps1
-    .\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
-    ```
+```ps1
+.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
+```
 
 *** 
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@
 
 5. Create Edge token and [query from edge](#query-edge)
 
-*** 
-
-## About this Solution
-This solution is designed to help developers learn and get started quickly
-with XMCLoud + SXA.
-
-## License File
+### License File
 
 If you store your license file in a central location, you can pass a LicenseXmlPath paramter to the init command to use that location. 
 
     ```ps1
     .\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"
     ```
+
+*** 
+
+## About this Solution
+This solution is designed to help developers learn and get started quickly
+with XMCLoud + SXA.

--- a/init.ps1
+++ b/init.ps1
@@ -4,10 +4,10 @@ Param (
         ParameterSetName = "env-init")]
     [switch]$InitEnv,
 
-    [Parameter(Mandatory = $true,
+    [Parameter(Mandatory = $false,
         HelpMessage = "The path to a valid Sitecore license.xml file.",
         ParameterSetName = "env-init")]
-    [string]$LicenseXmlPath,
+    [string]$LicenseXmlPath =".\license\license.xml",
 
     # We do not need to use [SecureString] here since the value will be stored unencrypted in .env,
     # and used only for transient local development environments.


### PR DESCRIPTION
Add a default convention to store the license file in a local folder with the option to specify a different location.